### PR TITLE
Remove pubsub abort hack

### DIFF
--- a/redis/__init__.py
+++ b/redis/__init__.py
@@ -22,7 +22,7 @@ from redis.exceptions import (
 )
 
 
-__version__ = '2.10.5.100'
+__version__ = '2.10.5.101'
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = [


### PR DESCRIPTION
This old hack was required to abort blocking calls to
.listen() but no longer required now with the
non-blocking .get_message().

Signed-off-by: Yehoshua Hershberg <yehoshua@redislabs.com>